### PR TITLE
Add deepwiki link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A simple tool for exploring documents with AI, no fancy text extraction required
 
 Here is a blog with release details about this project: [No-OCR Product](https://kyrylai.com/2025/01/10/no-ocr-product/)
 
+Additional background can be found on [DeepWiki](https://deepwiki.com/kyryl-opens-ml/no-ocr).
+
 ## Demo
 
 Here's a quick GIF demonstrating the basic flow of using No OCR:


### PR DESCRIPTION
## Summary
- add a link to the project's DeepWiki page in the README

## Testing
- `ruff check .`
- `pytest`
- `npm run lint` *(fails: '@eslint/js' module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684398fcdcfc8328bf6becc9b187c8fb