### PR TITLE
Respect model parameter in call_vllm

### DIFF
--- a/no-ocr-api/np_ocr/search.py
+++ b/no-ocr-api/np_ocr/search.py
@@ -134,7 +134,6 @@ def call_vllm(image_data: PIL.Image.Image, user_query: str, base_url: str, api_k
     logger.info("start call_vllm")
     start_time = time.time()
 
-    model = "Qwen2-VL-7B-Instruct"
 
     prompt = f"""
     Based on the user's query:

--- a/no-ocr-ui/src/stores/authStore.ts
+++ b/no-ocr-ui/src/stores/authStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { AuthState } from '../types/auth';
 import { supabase } from '../lib/supabase';
 
-export const useAuthStore = create<AuthState>((set) => ({
+export const useAuthStore = create<AuthState>(() => ({
   user: null,
   isLoading: true,
 }));


### PR DESCRIPTION
## Summary
- keep the `model` argument in `call_vllm` instead of forcing a constant
- fix unused variable lint error in UI store

## Testing
- `ruff check .`
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68625051ad108328a90cfe19b943606a