### PR TITLE
Remove debug prints

### DIFF
--- a/no-ocr-api/np_ocr/api.py
+++ b/no-ocr-api/np_ocr/api.py
@@ -180,7 +180,7 @@ def ai_search(user_query: str = Form(...), user_id: str = Form(...), case_name: 
 
     dataset = load_from_disk(dataset_path)
     search_results_data = []
-    print(search_results)
+    logger.info(search_results)
     for point in search_results:
         logger.info(point)
         score = point["_distance"]

--- a/no-ocr-api/np_ocr/search.py
+++ b/no-ocr-api/np_ocr/search.py
@@ -152,7 +152,7 @@ def call_vllm(image_data: PIL.Image.Image, user_query: str, base_url: str, api_k
     }}
     """
 
-    print(prompt)
+    logger.info(prompt)
     buffered = BytesIO()
     max_size = (512, 512)
     image_data.thumbnail(max_size)


### PR DESCRIPTION
## Summary
- use logger for debug output in call_vllm
- use logger for debug output in ai_search

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862505dffb483289b2a3da6e35b154b