### PR TITLE
Upgrade Vite and fix lint

### DIFF
--- a/no-ocr-ui/package-lock.json
+++ b/no-ocr-ui/package-lock.json
@@ -29,7 +29,7 @@
         "tailwindcss": "^3.4.1",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0",
-        "vite": "^5.4.2"
+        "vite": "^5.4.19"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3962,10 +3962,11 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
-      "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/no-ocr-ui/package.json
+++ b/no-ocr-ui/package.json
@@ -31,6 +31,6 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.19"
   }
 }

--- a/no-ocr-ui/src/stores/authStore.ts
+++ b/no-ocr-ui/src/stores/authStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { AuthState } from '../types/auth';
 import { supabase } from '../lib/supabase';
 
-export const useAuthStore = create<AuthState>((set) => ({
+export const useAuthStore = create<AuthState>(() => ({
   user: null,
   isLoading: true,
 }));


### PR DESCRIPTION
## Summary
- upgrade vite to 5.4.19
- fix auth store lint issue

## Testing
- `npm run lint`
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686250ad39008328aa3a973aedfb5dc6